### PR TITLE
Capture Retina pixels, idle the frame timer, and add Open at login

### DIFF
--- a/BendMac/AppModel.swift
+++ b/BendMac/AppModel.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Carbon
 import MetalKit
+import ServiceManagement
 import SwiftUI
 
 final class OverlayWindow: NSPanel {
@@ -23,6 +24,7 @@ final class OverlayWindow: NSPanel {
     @Published var shadow = 0.35 { didSet { save() } }
     @Published var clearAngle = 105.0 { didSet { save() } }
     @Published var sound = false { didSet { save() } }
+    @Published private(set) var openAtLogin = SMAppService.mainApp.status == .enabled
     let frames = FrameStore()
     let previewFrames = FrameStore()
     let sensor = LidSensor()
@@ -35,7 +37,9 @@ final class OverlayWindow: NSPanel {
     private var handler: EventHandlerRef?
     private var generation = 0
     private var stopping = false
-    private var wantsEnabled = false
+    private(set) var wantsEnabled = false {
+        didSet { UserDefaults.standard.set(wantsEnabled, forKey: "enabled") }
+    }
     private var sleeping = false
     private var reconnectTask: Task<Void, Never>?
     private var progress = 0.0
@@ -101,11 +105,9 @@ final class OverlayWindow: NSPanel {
                 }
             }
         }
-        let timer = Timer(timeInterval: 1 / 60.0, repeats: true) { [weak self] _ in
-            MainActor.assumeIsolated { self?.tick() }
-        }
-        self.timer = timer
-        RunLoop.main.add(timer, forMode: .common)
+        // Restore the effect after a relaunch, login, or update once the sensor reports.
+        wantsEnabled = defaults.bool(forKey: "enabled")
+        scheduleReconnect()
         var spec = EventTypeSpec(
             eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
         InstallEventHandler(
@@ -125,6 +127,15 @@ final class OverlayWindow: NSPanel {
         defaults.set(shadow, forKey: "shadow")
         defaults.set(clearAngle, forKey: "clearAngle")
         defaults.set(sound, forKey: "sound")
+    }
+    func setOpenAtLogin(_ on: Bool) {
+        do {
+            if on { try SMAppService.mainApp.register() } else { try SMAppService.mainApp.unregister() }
+        } catch {
+            status = "Could not change Open at login: \(error.localizedDescription)"
+        }
+        if SMAppService.mainApp.status == .requiresApproval { SMAppService.openSystemSettingsLoginItems() }
+        openAtLogin = SMAppService.mainApp.status == .enabled
     }
     func parameters(preview: Bool = false) -> BendParameters {
         var p = BendParameters()
@@ -188,6 +199,7 @@ final class OverlayWindow: NSPanel {
                 metalView = view
                 enabled = true
                 starting = false
+                startTicking()
                 progress = 0
                 sensor.setActive(true)
                 status = "Live desktop connected. Close the lid gently to bend it."
@@ -258,8 +270,24 @@ final class OverlayWindow: NSPanel {
     func playPreview() {
         playStart = CACurrentMediaTime()
         previewPlaying = true
+        startTicking()
+    }
+    /// Runs only while the effect or preview animates, so the idle menu bar app doesn't wake 60 times a second.
+    private func startTicking() {
+        guard timer == nil else { return }
+        lastTime = CACurrentMediaTime()
+        let timer = Timer(timeInterval: 1 / 60.0, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.tick() }
+        }
+        self.timer = timer
+        RunLoop.main.add(timer, forMode: .common)
     }
     private func tick() {
+        guard enabled || previewPlaying else {
+            timer?.invalidate()
+            timer = nil
+            return
+        }
         let now = CACurrentMediaTime()
         let dt = now - lastTime
         lastTime = now

--- a/BendMac/DesktopCapture.swift
+++ b/BendMac/DesktopCapture.swift
@@ -32,8 +32,10 @@ final class DesktopCapture: NSObject, SCStreamOutput, SCStreamDelegate {
         // Exclude our entire process to prevent recursive capture of the overlay and settings.
         let filter = SCContentFilter(display: display, excludingApplications: ownApp, exceptingWindows: [])
         let config = SCStreamConfiguration()
-        config.width = CGDisplayPixelsWide(displayID)
-        config.height = CGDisplayPixelsHigh(displayID)
+        // CGDisplayPixelsWide reports points; capture the backing pixels so Retina text stays sharp.
+        let mode = CGDisplayCopyDisplayMode(displayID)
+        config.width = mode?.pixelWidth ?? CGDisplayPixelsWide(displayID)
+        config.height = mode?.pixelHeight ?? CGDisplayPixelsHigh(displayID)
         config.minimumFrameInterval = CMTime(value: 1, timescale: 5)
         config.queueDepth = 3
         config.pixelFormat = kCVPixelFormatType_32BGRA

--- a/BendMac/Entry.swift
+++ b/BendMac/Entry.swift
@@ -32,7 +32,8 @@ import SwiftUI
         menu.addItem(
             withTitle: "Quit BendMac", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
         statusItem.menu = menu
-        openSettings()
+        // A restored session starts quietly in the menu bar.
+        if !model.wantsEnabled { openSettings() }
         if CommandLine.arguments.contains("--smoke") { model.enable() }
     }
     @objc func toggleEffect() { if model.enabled { model.disable() } else { model.enable() } }
@@ -62,7 +63,7 @@ import SwiftUI
         NSApp.activate(ignoringOtherApps: true)
         settings?.makeKeyAndOrderFront(nil)
     }
-    func applicationWillTerminate(_ notification: Notification) { model.disable() }
+    func applicationWillTerminate(_ notification: Notification) { model.disable(preserveIntent: true) }
 }
 @main enum BendMacMain {
     @MainActor static func main() {

--- a/BendMac/Renderer.swift
+++ b/BendMac/Renderer.swift
@@ -123,8 +123,10 @@ final class BendRenderer: NSObject, MTKViewDelegate {
     private func encodeBlur(_ source: MTLTexture, command: MTLCommandBuffer, strength: Float) -> [MTLTexture]
     {
         if strength < 0.001 { return [source, source, source, source] }
-        let w = max(1, source.width / 4)
-        let h = max(1, source.height / 4)
+        // ponytail: the blur base stays near its 1x size; sigma scales with w, so the look is unchanged
+        // and Retina captures don't quadruple blur cost.
+        let w = max(1, min(source.width / 4, 480))
+        let h = max(1, source.height * w / source.width)
         if blurTextures.first?.width != w || blurTextures.first?.height != h {
             let descriptor = MTLTextureDescriptor.texture2DDescriptor(
                 pixelFormat: .rgba8Unorm, width: w, height: h, mipmapped: false)

--- a/BendMac/SettingsView.swift
+++ b/BendMac/SettingsView.swift
@@ -367,6 +367,13 @@ struct SettingsView: View {
                     }
                     .toggleStyle(.switch).controlSize(.small).disabled(model.starting).padding(14)
                     rowDivider
+                    Toggle(isOn: Binding(get: { model.openAtLogin }, set: model.setOpenAtLogin)) {
+                        SettingCaption(
+                            title: "Open at login",
+                            detail: "Start in the menu bar and restore the effect if it was on.")
+                    }
+                    .toggleStyle(.switch).controlSize(.small).padding(14)
+                    rowDivider
                     Text(model.status).font(.system(size: 12)).foregroundStyle(.secondary)
                         .textSelection(.enabled).padding(14)
                 }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Adjust the style, blur, perspective, and shadow in Appearance. The preview works
 
 Press **Escape** to pause the effect. Close the settings window to leave BendMac running, or quit from the menu bar. Only the built-in display is affected.
 
+Turn on **General → Open at login** to start BendMac with your Mac. If the effect was on when you quit, it comes back on by itself.
+
 Use **Check for updates** to install future versions in the app. If you're on 0.4.0 or earlier, download the current version manually first.
 
 Screen frames stay in memory. Nothing is recorded to disk or uploaded, and audio isn't captured. Update checks contact GitHub to look for new releases.


### PR DESCRIPTION
## Summary

**Sharper bent desktop on Retina displays.** `DesktopCapture` sized the stream with `CGDisplayPixelsWide`, which returns points rather than pixels. On a 15" MacBook Air it reports 1710×1112, but the panel is 3420×2224. As a result, as soon as the lid dipped below the clear angle, the overlay swapped the real desktop for a half-resolution capture scaled up 2×. The stream is now sized from `CGDisplayCopyDisplayMode(...).pixelWidth/pixelHeight`.
- `encodeBlur` now caps its working width at 480 px, so blur cost doesn't grow with the larger capture. Blur sigma already scales with that width, so the look doesn't change.

**No idle wakeups.** The 60 Hz `tick()` timer used to run for the app's whole lifetime, even with the effect off. It now starts when the effect is enabled or the preview plays, and stops itself when neither is active.

**Open at login.** Adds a toggle under General → Desktop effect, using `SMAppService.mainApp`. If macOS needs the user to approve the login item, the toggle opens Login Items in System Settings. Failures appear in the status line.
- The app now remembers whether the effect was on. It's restored after a relaunch, login, or Sparkle update, and a restored session starts in the menu bar without opening Settings.
- Quitting no longer turns the effect off; Escape and the toggle still do.
- The restore goes through the existing `scheduleReconnect()`, which waits for the lid sensor's first reading.
- The README describes the new toggle.

## Validation

- The math tests in `Tests/main.swift` pass.
- All app sources typecheck with `swiftc -typecheck` (macOS 14 target). Sparkle and SwiftUI's `@State` macro were stubbed, because I only had the Command Line Tools and no Xcode.
- `swift-format lint` reports no new warnings on the changed files.
- I checked the points-vs-pixels mismatch on a real 15" MacBook Air (M-series): `CGDisplayPixelsWide` returns 1710×1112 and the display mode's pixel size is 3420×2224.

**Not verified:** I couldn't build or run the app without Xcode and the Metal toolchain. That means:
- the live effect hasn't been checked on hardware;
- the `--render-proof` / `--sensor-check` steps in `scripts/verify.sh` weren't run;
- `SMAppService` hasn't been tried on this ad-hoc-signed build.

Please run `scripts/verify.sh` and try the toggle on a real Mac before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an “Open at login” option in General settings.
  - BendMac can start in the menu bar and restore the effect after login when previously enabled.

- **Bug Fixes**
  - Improved display capture quality on Retina and high-resolution screens.
  - Refined blur rendering for more consistent performance.
  - Prevented unnecessary settings windows from opening when the effect is already active.

- **Documentation**
  - Updated the README with details about the login startup option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->